### PR TITLE
Acesso à home por meio de varriável de ambiente

### DIFF
--- a/envvars
+++ b/envvars
@@ -1,3 +1,3 @@
 export GPG_TTY=$(tty)
-export PATH="/home/pedro/.dotnet:$PATH"
+export PATH="$HOME/.dotnet:$PATH"
 export DOTNET_CLI_UI_LANGUAGE="en"


### PR DESCRIPTION
Em ambientes linux se você usar `echo $SHOME` ele imprime o diretório `/home/<nome do usuário>`. Suponho que talvez a solução funcione 😅